### PR TITLE
Don't regard empty 'Damjiro Gakufu Input' as error

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -294,7 +294,14 @@ function InputDamjiroGakufu ({ dispatch }) {
         }}
         variant={'outlined'}
         onChange={e => {
+          dispatch({ type: 'RESET_USER_NOTES' })
           setGakufuText(e.target.value)
+
+          if (e.target.value === '') {
+            setErrorMsg(null)
+            return
+          }
+
           try {
             const json = JSON.parse(e.target.value)
             const notes = json.notes.map(n => ({
@@ -324,7 +331,6 @@ function InputDamjiroGakufu ({ dispatch }) {
               variant: 'error'
             })
           }
-          dispatch({ type: 'RESET_USER_NOTES' })
         }}
       />
     </FormControl>


### PR DESCRIPTION
"Damjiro Gakufu Input" が空のときはエラーとしない。

現状、初期状態ではエラーとなっていないが、書き込んでから全消去するとエラーの表示となる。これを修正。