### PR TITLE
Fix invalid closing of AudioContext

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -164,7 +164,6 @@ async function createPitchDetector (audioContext) {
   }
   const stopAudio = () => {
     stream.getTracks().forEach(track => track.stop())
-    audioContext.close()
   }
 
   return [getPitch, stopAudio]


### PR DESCRIPTION
ここで `AudioContext` を閉じると、二度目にMIDIファイルを読み込む際に、closeしたあとのAudioContextをresumeする形になるためエラーになるのを修正。